### PR TITLE
Feat: Solana tx history tokens

### DIFF
--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -31,7 +31,7 @@ export interface ServerInfo {
     consensusBranchId?: number; // zcash current branch id
 }
 
-export type TokenStandard = 'ERC20' | 'ERC1155' | 'ERC721';
+export type TokenStandard = 'ERC20' | 'ERC1155' | 'ERC721' | 'SPL';
 
 export type TransferType = 'sent' | 'recv' | 'self' | 'unknown';
 

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -17,6 +17,7 @@
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
+        "@solana/web3.js": "^1.78.4",
         "@trezor/utils": "workspace:*",
         "bignumber.js": "^9.1.1"
     },

--- a/packages/blockchain-link-utils/src/index.ts
+++ b/packages/blockchain-link-utils/src/index.ts
@@ -1,3 +1,4 @@
 export * from './utils';
 export * as blockbookUtils from './blockbook';
 export * as blockfrostUtils from './blockfrost';
+export * as solanaUtils from './solana';

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -107,3 +107,16 @@ export const getTxType = (
 
     return 'unknown';
 };
+
+export function getAmount(
+    accountEffect: TransactionEffect | undefined,
+    txType: Transaction['type'],
+) {
+    if (!accountEffect) {
+        return '0';
+    }
+    if (txType === 'self') {
+        return accountEffect.amount?.abs().toString();
+    }
+    return accountEffect.amount.toString();
+}

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -1,0 +1,45 @@
+import { ParsedTransactionWithMeta } from '@solana/web3.js';
+import BigNumber from 'bignumber.js';
+export function extractAccountBalanceDiff(
+    transaction: ParsedTransactionWithMeta,
+    address: string,
+): {
+    preBalance: BigNumber;
+    postBalance: BigNumber;
+} | null {
+    const pubKeyIndex = transaction.transaction.message.accountKeys.findIndex(
+        ak => ak.pubkey.toString() === address,
+    );
+
+    if (pubKeyIndex === -1) {
+        return null;
+    }
+
+    return {
+        preBalance: new BigNumber(transaction.meta?.preBalances[pubKeyIndex] ?? 0),
+        postBalance: new BigNumber(transaction.meta?.postBalances[pubKeyIndex] ?? 0),
+    };
+}
+type TransactionEffect = {
+    address: string;
+    amount: BigNumber;
+};
+
+export function getTransactionEffects(transaction: ParsedTransactionWithMeta): TransactionEffect[] {
+    return transaction.transaction.message.accountKeys
+        .map(ak => {
+            const targetAddress = ak.pubkey.toString();
+            const balanceDiff = extractAccountBalanceDiff(transaction, targetAddress);
+            if (!balanceDiff) {
+                return null;
+            }
+
+            return {
+                address: targetAddress,
+                amount: balanceDiff.postBalance.minus(balanceDiff.preBalance),
+            };
+        })
+        .filter((effect): effect is TransactionEffect => !!effect)
+        .filter(({ amount }) => !amount.isZero()); // filter out zero effects
+}
+

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -154,6 +154,7 @@ export function getAmount(
 export const transformTransaction = (
     tx: ParsedTransactionWithMeta,
     accountAddress: string,
+    slotToBlockHeightMapping: Record<number, number | null>,
 ): Transaction | null => {
     if (!tx || !tx.meta || !tx.transaction || !tx.blockTime) {
         return null;

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -85,6 +85,18 @@ export const getTxType = (
         return 'failed';
     }
 
+    const isTransfer = transaction.transaction.message.instructions.every(instruction => {
+        const isParsedInstruction = 'parsed' in instruction;
+        return isParsedInstruction && instruction.parsed.type === 'transfer';
+    });
+
+    // for now we support only transfers, so we interpret all other transactions as `unknown`
+    if (!isTransfer) {
+        return 'unknown';
+    }
+
+    // TODO(vl): phase two, isTokenTx
+
     if (
         effects.length === 1 &&
         effects[0]?.address === accountAddress &&

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -1,4 +1,4 @@
-import { ParsedTransactionWithMeta } from '@solana/web3.js';
+import { ParsedInstruction, ParsedTransactionWithMeta } from '@solana/web3.js';
 import BigNumber from 'bignumber.js';
 import { Target, Transaction } from 'packages/blockchain-link-types/lib';
 
@@ -85,37 +85,43 @@ export const getTxType = (
         return 'failed';
     }
 
-    const isTransfer = transaction.transaction.message.instructions.every(instruction => {
-        const isParsedInstruction = 'parsed' in instruction;
-        return isParsedInstruction && instruction.parsed.type === 'transfer';
-    });
+    // we consider only parsed instructions because only based on them we can determine the type of transaction
+    const parsedInstructions = transaction.transaction.message.instructions.filter(
+        (instruction): instruction is ParsedInstruction => 'parsed' in instruction,
+    );
 
-    // for now we support only transfers, so we interpret all other transactions as `unknown`
-    if (!isTransfer) {
+    if (parsedInstructions.length === 0) {
         return 'unknown';
     }
 
+    const isTransfer = parsedInstructions.every(
+        instruction => instruction.parsed.type === 'transfer',
+    );
+
+    // for now we support only transfers, so we interpret all other transactions as `unknown`
+    if (isTransfer) {
+        if (
+            effects.length === 1 &&
+            effects[0]?.address === accountAddress &&
+            effects[0]?.amount.abs().isEqualTo(new BigNumber(transaction.meta?.fee || 0))
+        ) {
+            return 'self';
+        }
+
+        const senders = effects.filter(({ amount }) => amount.isNegative());
+
+        if (senders.find(({ address }) => address === accountAddress)) {
+            return 'sent';
+        }
+
+        const receivers = effects.filter(({ amount }) => amount.isPositive());
+
+        if (receivers.find(({ address }) => address === accountAddress)) {
+            return 'recv';
+        }
+    }
+
     // TODO(vl): phase two, isTokenTx
-
-    if (
-        effects.length === 1 &&
-        effects[0]?.address === accountAddress &&
-        effects[0]?.amount.abs().isEqualTo(new BigNumber(transaction.meta?.fee || 0))
-    ) {
-        return 'self';
-    }
-
-    const senders = effects.filter(({ amount }) => amount.isNegative());
-
-    if (senders.find(({ address }) => address === accountAddress)) {
-        return 'sent';
-    }
-
-    const receivers = effects.filter(({ amount }) => amount.isPositive());
-
-    if (receivers.find(({ address }) => address === accountAddress)) {
-        return 'recv';
-    }
 
     return 'unknown';
 };

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -1,6 +1,6 @@
 import { ParsedTransactionWithMeta } from '@solana/web3.js';
 import BigNumber from 'bignumber.js';
-import { Transaction } from 'packages/blockchain-link-types/lib';
+import { Target, Transaction } from 'packages/blockchain-link-types/lib';
 
 export function extractAccountBalanceDiff(
     transaction: ParsedTransactionWithMeta,
@@ -22,6 +22,7 @@ export function extractAccountBalanceDiff(
         postBalance: new BigNumber(transaction.meta?.postBalances[pubKeyIndex] ?? 0),
     };
 }
+
 type TransactionEffect = {
     address: string;
     amount: BigNumber;
@@ -43,6 +44,36 @@ export function getTransactionEffects(transaction: ParsedTransactionWithMeta): T
         })
         .filter((effect): effect is TransactionEffect => !!effect)
         .filter(({ amount }) => !amount.isZero()); // filter out zero effects
+}
+
+export function getTargets(
+    effects: TransactionEffect[],
+    txType: Transaction['type'],
+    accountAddress: string,
+): Transaction['targets'] {
+    return effects
+        .filter(effect => {
+            // for 'self` transaction there is only one effect
+            if (txType === 'self') {
+                return true;
+            }
+            // ignore all targets for unknown transactions
+            if (txType === 'unknown') {
+                return false;
+            }
+            // count in only positive effects, for `sent` tx they gonna be represented as negative, for `recv` as positive
+            return effect.amount.isGreaterThan(0);
+        })
+        .map((effect, i) => {
+            const target: Target = {
+                n: i,
+                addresses: [effect.address],
+                isAddress: true,
+                amount: effect.amount.abs().toString(),
+                isAccountTarget: effect.address === accountAddress && txType !== 'sent',
+            };
+            return target;
+        });
 }
 
 export const getTxType = (

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -1,10 +1,15 @@
-import { ParsedInstruction, ParsedTransactionWithMeta } from '@solana/web3.js';
+import {
+    ParsedInstruction,
+    ParsedTransactionWithMeta,
+    PartiallyDecodedInstruction,
+} from '@solana/web3.js';
 import BigNumber from 'bignumber.js';
-import { Target, Transaction } from 'packages/blockchain-link-types/lib';
+import { Target, TokenTransfer, Transaction } from 'packages/blockchain-link-types/lib';
 
 export function extractAccountBalanceDiff(
     transaction: ParsedTransactionWithMeta,
     address: string,
+    isTokenDiff = false,
 ): {
     preBalance: BigNumber;
     postBalance: BigNumber;
@@ -17,22 +22,64 @@ export function extractAccountBalanceDiff(
         return null;
     }
 
+    if (isTokenDiff) {
+        const preBalance = transaction.meta?.preTokenBalances?.find(
+            balance => balance.accountIndex === pubKeyIndex,
+        )?.uiTokenAmount.amount;
+        const postBalance = transaction.meta?.postTokenBalances?.find(
+            balance => balance.accountIndex === pubKeyIndex,
+        )?.uiTokenAmount.amount;
+
+        return {
+            preBalance: new BigNumber(preBalance ?? 0),
+            postBalance: new BigNumber(postBalance ?? 0),
+        };
+    }
+
+    const preBalance = transaction.meta?.preBalances[pubKeyIndex];
+
+    const postBalance = transaction.meta?.postBalances[pubKeyIndex];
+
     return {
-        preBalance: new BigNumber(transaction.meta?.preBalances[pubKeyIndex] ?? 0),
-        postBalance: new BigNumber(transaction.meta?.postBalances[pubKeyIndex] ?? 0),
+        preBalance: new BigNumber(preBalance ?? 0),
+        postBalance: new BigNumber(postBalance ?? 0),
     };
 }
+
+const isWSolTransfer = (ixs: (ParsedInstruction | PartiallyDecodedInstruction)[]) =>
+    ixs.find(
+        ix =>
+            'parsed' in ix &&
+            ix.parsed.info?.mint === 'So11111111111111111111111111111111111111112',
+    );
 
 type TransactionEffect = {
     address: string;
     amount: BigNumber;
 };
 
-export function getTransactionEffects(transaction: ParsedTransactionWithMeta): TransactionEffect[] {
+export function getNativeEffects(transaction: ParsedTransactionWithMeta): TransactionEffect[] {
+    // TODO(vl): after token PR is merged, get WSOL mint from there
+    const wSolTransferInstruction = isWSolTransfer(
+        transaction.transaction.message.instructions || [],
+    );
+
     return transaction.transaction.message.accountKeys
         .map(ak => {
             const targetAddress = ak.pubkey.toString();
             const balanceDiff = extractAccountBalanceDiff(transaction, targetAddress);
+
+            // WSOL Transfers are counted as SOL transfers in the transaction effects, leading to duplicate
+            // entries in the tx history. This serves to filter out the WSOL transfers from the native effects.
+            if (wSolTransferInstruction && 'parsed' in wSolTransferInstruction) {
+                if (
+                    wSolTransferInstruction.parsed.info.destination === targetAddress ||
+                    wSolTransferInstruction.parsed.info.source === targetAddress
+                ) {
+                    return null;
+                }
+            }
+
             if (!balanceDiff) {
                 return null;
             }
@@ -76,10 +123,51 @@ export function getTargets(
         });
 }
 
+const getTokenTransferTxType = (transfers: TokenTransfer[]) => {
+    if (transfers.every(({ type }) => type === 'recv')) {
+        return 'recv';
+    }
+
+    if (transfers.every(({ type }) => type === 'sent')) {
+        return 'sent';
+    }
+
+    return 'unknown';
+};
+
+const getNativeTransferTxType = (
+    effects: TransactionEffect[],
+    accountAddress: string,
+    transaction: ParsedTransactionWithMeta,
+) => {
+    if (
+        effects.length === 1 &&
+        effects[0]?.address === accountAddress &&
+        effects[0]?.amount.abs().isEqualTo(new BigNumber(transaction.meta?.fee || 0))
+    ) {
+        return 'self';
+    }
+
+    const senders = effects.filter(({ amount }) => amount.isNegative());
+
+    if (senders.find(({ address }) => address === accountAddress)) {
+        return 'sent';
+    }
+
+    const receivers = effects.filter(({ amount }) => amount.isPositive());
+
+    if (receivers.find(({ address }) => address === accountAddress)) {
+        return 'recv';
+    }
+
+    return 'unknown';
+};
+
 export const getTxType = (
     transaction: ParsedTransactionWithMeta,
     effects: TransactionEffect[],
     accountAddress: string,
+    tokenTransfers: TokenTransfer[],
 ): Transaction['type'] => {
     if (transaction.meta?.err) {
         return 'failed';
@@ -94,34 +182,23 @@ export const getTxType = (
         return 'unknown';
     }
 
+    const isInstructionCreatingTokenAccount = (instruction: ParsedInstruction) =>
+        instruction.program === 'spl-associated-token-account' &&
+        instruction.parsed.type === 'create';
+
     const isTransfer = parsedInstructions.every(
-        instruction => instruction.parsed.type === 'transfer',
+        instruction =>
+            instruction.parsed.type === 'transfer' ||
+            instruction.parsed.type === 'transferChecked' ||
+            isInstructionCreatingTokenAccount(instruction),
     );
 
     // for now we support only transfers, so we interpret all other transactions as `unknown`
     if (isTransfer) {
-        if (
-            effects.length === 1 &&
-            effects[0]?.address === accountAddress &&
-            effects[0]?.amount.abs().isEqualTo(new BigNumber(transaction.meta?.fee || 0))
-        ) {
-            return 'self';
-        }
-
-        const senders = effects.filter(({ amount }) => amount.isNegative());
-
-        if (senders.find(({ address }) => address === accountAddress)) {
-            return 'sent';
-        }
-
-        const receivers = effects.filter(({ amount }) => amount.isPositive());
-
-        if (receivers.find(({ address }) => address === accountAddress)) {
-            return 'recv';
-        }
+        return tokenTransfers.length > 0
+            ? getTokenTransferTxType(tokenTransfers)
+            : getNativeTransferTxType(effects, accountAddress, transaction);
     }
-
-    // TODO(vl): phase two, isTokenTx
 
     return 'unknown';
 };
@@ -169,6 +246,42 @@ export function getAmount(
     return accountEffect.amount.toString();
 }
 
+export const getTokens = (
+    tx: ParsedTransactionWithMeta,
+    accountAddress: string,
+): TokenTransfer[] => {
+    const effects = tx.transaction.message.instructions
+        .filter((ix): ix is ParsedInstruction => 'parsed' in ix)
+        .filter(
+            ix =>
+                ix.program === 'spl-token' &&
+                (ix.parsed.type === 'transfer' || ix.parsed.type === 'transferChecked'),
+        )
+        .map((ix): TokenTransfer => {
+            const { parsed } = ix;
+
+            // Accounting for 'self' transfers would involve fetching owned token account data from RPC
+            // and comparing it with the destination address. This is overkill for most users and thus it is
+            // left unimplemented.
+            const uiType = parsed.info.authority === accountAddress ? 'sent' : 'recv';
+
+            // TODO(vl): get token name and symbol properly once token PR is merged
+            return {
+                type: uiType,
+                standard: 'SPL',
+                from: parsed.info.authority,
+                to: parsed.info.destination,
+                contract: parsed.info.mint,
+                decimals: parsed.info.tokenAmount?.decimals || 0,
+                name: parsed.info.mint,
+                symbol: `${parsed.info.mint.slice(0, 3)}...`,
+                amount: parsed.info.tokenAmount?.amount || '-1',
+            };
+        });
+
+    return effects;
+};
+
 export const transformTransaction = (
     tx: ParsedTransactionWithMeta,
     accountAddress: string,
@@ -178,16 +291,20 @@ export const transformTransaction = (
         return null;
     }
 
-    const effects = getTransactionEffects(tx);
+    const nativeEffects = getNativeEffects(tx);
 
-    const type = getTxType(tx, effects, accountAddress);
+    const tokens = getTokens(tx, accountAddress);
 
-    const targets = getTargets(effects, type, accountAddress);
+    const type = getTxType(tx, nativeEffects, accountAddress, tokens);
+
+    const targets = getTargets(nativeEffects, type, accountAddress);
 
     const amount = getAmount(
-        effects.find(({ address }) => address === accountAddress),
+        nativeEffects.find(({ address }) => address === accountAddress),
         type,
     );
+
+    const details = getDetails(tx, nativeEffects, accountAddress);
 
     return {
         type,
@@ -196,9 +313,9 @@ export const transformTransaction = (
         amount,
         fee: tx.meta.fee.toString(),
         targets,
-        tokens: [], // TODO(vl): phase 2
+        tokens,
         internalTransfers: [], // not relevant for solana
-        details: getDetails(tx, effects, accountAddress),
+        details,
         blockHeight: slotToBlockHeightMapping[tx.slot] || undefined,
         blockHash: tx.transaction.message.recentBlockhash,
     };

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -20,6 +20,7 @@ const parsedTransactions = {
             },
             version: 'legacy',
             blockTime: 1631753600,
+            slot: 5,
         },
     },
     withoutMeta: {
@@ -338,6 +339,7 @@ export const fixtures = {
             input: {
                 transaction: null,
                 accountAddress: 'myAddress',
+                slotToBlockHeightMapping: {},
             },
             expectedOutput: null,
         },
@@ -351,6 +353,7 @@ export const fixtures = {
                     blockTime: 1631753600,
                 },
                 accountAddress: 'myAddress',
+                slotToBlockHeightMapping: {},
             },
             expectedOutput: null,
         },
@@ -362,6 +365,7 @@ export const fixtures = {
                     blockTime: 1631753600,
                 },
                 accountAddress: 'myAddress',
+                slotToBlockHeightMapping: {},
             },
             expectedOutput: null,
         },
@@ -375,6 +379,7 @@ export const fixtures = {
                     },
                 },
                 accountAddress: 'myAddress',
+                slotToBlockHeightMapping: {},
             },
             expectedOutput: null,
         },
@@ -383,11 +388,13 @@ export const fixtures = {
             input: {
                 transaction: parsedTransactions.basic.transaction,
                 accountAddress: effects.negative.address,
+                slotToBlockHeightMapping: { 5: 20 },
             },
             expectedOutput: {
                 type: 'sent',
                 txid: 'txid1',
                 blockTime: 1631753600,
+                blockHeight: 20,
                 amount: '-20',
                 fee: '10',
                 targets: [

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -54,6 +54,26 @@ const parsedTransactions = {
             },
         },
     },
+    justWithFee: {
+        transaction: {
+            transaction: {
+                meta: {
+                    fee: 10,
+                },
+            },
+        },
+    },
+};
+
+const effects = {
+    negative: {
+        address: 'address1',
+        amount: new BigNumber(-20),
+    },
+    positive: {
+        address: 'address2',
+        amount: new BigNumber(10),
+    },
 };
 
 export const fixtures = {
@@ -108,6 +128,64 @@ export const fixtures = {
                     amount: new BigNumber(10),
                 },
             ],
+        },
+    ],
+    getTxType: [
+        {
+            description: 'should return "failed" if the transaction has an error',
+            input: {
+                transaction: {
+                    meta: {
+                        fee: 10,
+                        err: 'Transaction failed',
+                    },
+                },
+                effects: [],
+                accountAddress: 'myAddress',
+            },
+            expectedOutput: 'failed',
+        },
+        {
+            description: 'should return "self" if it matches a self-transaction with fee',
+            input: {
+                transaction: {
+                    meta: {
+                        fee: effects.negative.amount.abs().toNumber(),
+                    },
+                },
+                effects: [effects.negative],
+                accountAddress: effects.negative.address,
+            },
+            expectedOutput: 'self',
+        },
+        {
+            description:
+                'should return "sent" if there are negative effects and the account address is a sender',
+            input: {
+                transaction: parsedTransactions.justWithFee.transaction,
+                effects: [effects.negative],
+                accountAddress: effects.negative.address,
+            },
+            expectedOutput: 'sent',
+        },
+        {
+            description:
+                'should return "recv" if there are positive effects and the account address is a receiver',
+            input: {
+                transaction: parsedTransactions.justWithFee.transaction,
+                effects: [effects.positive],
+                accountAddress: effects.positive.address,
+            },
+            expectedOutput: 'recv',
+        },
+        {
+            description: 'should return "unknown" if none of the conditions match',
+            input: {
+                transaction: parsedTransactions.justWithFee.transaction,
+                effects: [effects.positive],
+                accountAddress: 'someOtherAddress',
+            },
+            expectedOutput: 'unknown',
         },
     ],
 };

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -1,5 +1,19 @@
 import BigNumber from 'bignumber.js';
 
+const instructions = {
+    transfer: {
+        parsed: {
+            type: 'transfer',
+        },
+    },
+    nonTransfer: {
+        parsed: {
+            type: 'nonTransfer',
+        },
+    },
+    notParsed: {},
+};
+
 const parsedTransactions = {
     basic: {
         transaction: {
@@ -16,6 +30,7 @@ const parsedTransactions = {
                         { pubkey: { toString: () => 'address1' } },
                         { pubkey: { toString: () => 'address2' } },
                     ],
+                    instructions: [instructions.transfer],
                 },
             },
             version: 'legacy',
@@ -76,9 +91,12 @@ const parsedTransactions = {
     justWithFee: {
         transaction: {
             transaction: {
-                meta: {
-                    fee: 10,
+                message: {
+                    instructions: [instructions.transfer],
                 },
+            },
+            meta: {
+                fee: 5,
             },
         },
     },
@@ -165,11 +183,46 @@ export const fixtures = {
             expectedOutput: 'failed',
         },
         {
+            description: 'should return "unknown" if instructions are not transfer',
+            input: {
+                transaction: {
+                    transaction: {
+                        message: {
+                            instructions: [instructions.nonTransfer],
+                        },
+                    },
+                },
+                effects: [effects.negative],
+                accountAddress: effects.negative.address,
+            },
+            expectedOutput: 'unknown',
+        },
+        {
+            description: 'should return "unknown" if at least single instruction is not parsed',
+            input: {
+                transaction: {
+                    transaction: {
+                        message: {
+                            instructions: [instructions.notParsed],
+                        },
+                    },
+                },
+                effects: [effects.negative],
+                accountAddress: effects.negative.address,
+            },
+            expectedOutput: 'unknown',
+        },
+        {
             description: 'should return "self" if it matches a self-transaction with fee',
             input: {
                 transaction: {
+                    transaction: {
+                        message: {
+                            instructions: [instructions.transfer],
+                        },
+                    },
                     meta: {
-                        fee: effects.negative.amount.abs().toNumber(),
+                        fee: effects.negative.amount.abs().toString(),
                     },
                 },
                 effects: [effects.negative],

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -250,4 +250,31 @@ export const fixtures = {
             expectedOutput: [],
         },
     ],
+    getAmount: [
+        {
+            description: 'should return "0" if accountEffect is undefined',
+            input: {
+                accountEffect: undefined,
+                txType: 'recv',
+            },
+            expectedOutput: '0',
+        },
+        {
+            description:
+                'should return the absolute amount as a string for "self" transaction type',
+            input: {
+                accountEffect: effects.negative,
+                txType: 'self',
+            },
+            expectedOutput: effects.negative.amount.abs().toString(),
+        },
+        {
+            description: 'should return the amount as a string for other transaction types',
+            input: {
+                accountEffect: effects.positive,
+                txType: 'unknown',
+            },
+            expectedOutput: effects.positive.amount.toString(),
+        },
+    ],
 };

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -188,4 +188,66 @@ export const fixtures = {
             expectedOutput: 'unknown',
         },
     ],
+    getTargets: [
+        {
+            description: 'should return an array with a target for "self" transaction type',
+            input: {
+                effects: [effects.negative],
+                txType: 'self',
+                accountAddress: effects.negative.address,
+            },
+            expectedOutput: [
+                {
+                    n: 0,
+                    addresses: [effects.negative.address],
+                    isAddress: true,
+                    amount: effects.negative.amount.abs().toString(),
+                    isAccountTarget: true,
+                },
+            ],
+        },
+        {
+            description: 'should return an array with a target for "sent" transaction type',
+            input: {
+                effects: [effects.positive, effects.negative],
+                txType: 'sent',
+                accountAddress: effects.negative.address,
+            },
+            expectedOutput: [
+                {
+                    n: 0,
+                    addresses: [effects.positive.address],
+                    isAddress: true,
+                    amount: effects.positive.amount.abs().toString(),
+                    isAccountTarget: false,
+                },
+            ],
+        },
+        {
+            description: 'should return an array with a target for "recv" transaction type',
+            input: {
+                effects: [effects.positive, effects.negative],
+                txType: 'recv',
+                accountAddress: effects.positive.address,
+            },
+            expectedOutput: [
+                {
+                    n: 0,
+                    addresses: [effects.positive.address],
+                    isAddress: true,
+                    amount: effects.positive.amount.abs().toString(),
+                    isAccountTarget: true,
+                },
+            ],
+        },
+        {
+            description: 'should return an empty array for "unknown" transaction type',
+            input: {
+                effects: [effects.positive, effects.negative],
+                txType: 'unknown',
+                accountAddress: 'someOtherAddress',
+            },
+            expectedOutput: [],
+        },
+    ],
 };

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -1,6 +1,17 @@
 import BigNumber from 'bignumber.js';
 
 const parsedTransactions = {
+    basic: {
+        transaction: {
+            meta: {
+                computeUnitsConsumed: 100,
+            },
+            transaction: {
+                signatures: ['txid1'],
+            },
+            version: 'legacy',
+        },
+    },
     withoutMeta: {
         transaction: {
             transaction: {
@@ -275,6 +286,43 @@ export const fixtures = {
                 txType: 'unknown',
             },
             expectedOutput: effects.positive.amount.toString(),
+        },
+    ],
+    getDetails: [
+        {
+            description: 'should return transaction details with valid inputs',
+            input: {
+                transaction: parsedTransactions.basic.transaction,
+                effects: [effects.positive, effects.negative],
+                accountAddress: effects.negative.address,
+            },
+            expectedOutput: {
+                size: parsedTransactions.basic.transaction.meta.computeUnitsConsumed,
+                totalInput: effects.negative.amount.abs().toString(),
+                totalOutput: effects.positive.amount.abs().toString(),
+                vin: [
+                    {
+                        txid: 'txid1',
+                        version: 'legacy',
+                        isAddress: true,
+                        isAccountOwned: true,
+                        n: 0,
+                        value: effects.negative.amount.abs().toString(),
+                        addresses: [effects.negative.address],
+                    },
+                ],
+                vout: [
+                    {
+                        txid: 'txid1',
+                        version: 'legacy',
+                        isAddress: true,
+                        isAccountOwned: false,
+                        n: 0,
+                        value: effects.positive.amount.abs().toString(),
+                        addresses: [effects.positive.address],
+                    },
+                ],
+            },
         },
     ],
 };

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -1,0 +1,113 @@
+import BigNumber from 'bignumber.js';
+
+const parsedTransactions = {
+    withoutMeta: {
+        transaction: {
+            transaction: {
+                message: {
+                    accountKeys: [
+                        { pubkey: { toString: () => 'address1' } },
+                        { pubkey: { toString: () => 'address2' } },
+                    ],
+                },
+            },
+        },
+    },
+    withMeta: {
+        transaction: {
+            meta: {
+                preBalances: [100, 200],
+                postBalances: [110, 210],
+            },
+            transaction: {
+                message: {
+                    accountKeys: [
+                        { pubkey: { toString: () => 'address1' } },
+                        { pubkey: { toString: () => 'address2' } },
+                    ],
+                },
+            },
+        },
+    },
+    empty: {
+        transaction: {
+            transaction: {
+                message: {
+                    accountKeys: [],
+                },
+            },
+        },
+    },
+    withZeroEffects: {
+        transaction: {
+            transaction: {
+                message: {
+                    accountKeys: [
+                        { pubkey: { toString: () => 'address1' } },
+                        { pubkey: { toString: () => 'address2' } },
+                    ],
+                },
+            },
+            meta: {
+                preBalances: [100, 200],
+                postBalances: [100, 200],
+            },
+        },
+    },
+};
+
+export const fixtures = {
+    extractAccountBalanceDiff: [
+        {
+            description: 'should return null if the address is not found in the transaction',
+            input: {
+                transaction: parsedTransactions.withMeta.transaction,
+                address: 'nonexistentAddress',
+            },
+            expectedOutput: null,
+        },
+        {
+            description:
+                'should return preBalance and postBalance if the address is found in the transaction',
+            input: { transaction: parsedTransactions.withMeta.transaction, address: 'address2' },
+            expectedOutput: {
+                preBalance: new BigNumber(200),
+                postBalance: new BigNumber(210),
+            },
+        },
+        {
+            description: 'should return default values (0) if meta is not provided',
+            input: { transaction: parsedTransactions.withoutMeta.transaction, address: 'address1' },
+            expectedOutput: {
+                preBalance: new BigNumber(0),
+                postBalance: new BigNumber(0),
+            },
+        },
+    ],
+    getTransactionEffects: [
+        {
+            description: 'should return an empty array if there are no account keys',
+            input: parsedTransactions.empty,
+            expectedOutput: [],
+        },
+        {
+            description: 'should return an empty array if there are no effects',
+            input: parsedTransactions.withZeroEffects,
+            expectedOutput: [],
+        },
+        {
+            description: 'should return transaction effects',
+            input: parsedTransactions.withMeta,
+            expectedOutput: [
+                {
+                    address: 'address1',
+                    amount: new BigNumber(10),
+                },
+                {
+                    address: 'address2',
+                    amount: new BigNumber(10),
+                },
+            ],
+        },
+    ],
+};

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -5,21 +5,28 @@ const parsedTransactions = {
         transaction: {
             meta: {
                 computeUnitsConsumed: 100,
+                preBalances: [200, 100],
+                postBalances: [180, 110],
+                fee: 10,
             },
             transaction: {
                 signatures: ['txid1'],
+                message: {
+                    accountKeys: [
+                        { pubkey: { toString: () => 'address1' } },
+                        { pubkey: { toString: () => 'address2' } },
+                    ],
+                },
             },
             version: 'legacy',
+            blockTime: 1631753600,
         },
     },
     withoutMeta: {
         transaction: {
             transaction: {
                 message: {
-                    accountKeys: [
-                        { pubkey: { toString: () => 'address1' } },
-                        { pubkey: { toString: () => 'address2' } },
-                    ],
+                    accountKeys: [{ pubkey: { toString: () => 'address1' } }],
                 },
             },
         },
@@ -322,6 +329,105 @@ export const fixtures = {
                         addresses: [effects.positive.address],
                     },
                 ],
+            },
+        },
+    ],
+    transformTransaction: [
+        {
+            description: 'should return null when tx is null',
+            input: {
+                transaction: null,
+                accountAddress: 'myAddress',
+            },
+            expectedOutput: null,
+        },
+        {
+            description: 'should return null when tx.meta is null',
+            input: {
+                transaction: {
+                    transaction: {
+                        signatures: ['txid1'],
+                    },
+                    blockTime: 1631753600,
+                },
+                accountAddress: 'myAddress',
+            },
+            expectedOutput: null,
+        },
+        {
+            description: 'should return null when tx.transaction is null',
+            input: {
+                transaction: {
+                    meta: {},
+                    blockTime: 1631753600,
+                },
+                accountAddress: 'myAddress',
+            },
+            expectedOutput: null,
+        },
+        {
+            description: 'should return null when tx.blockTime is null',
+            input: {
+                transaction: {
+                    meta: {},
+                    transaction: {
+                        signatures: ['txid2'],
+                    },
+                },
+                accountAddress: 'myAddress',
+            },
+            expectedOutput: null,
+        },
+        {
+            description: 'should return a valid Transaction object when all inputs are valid',
+            input: {
+                transaction: parsedTransactions.basic.transaction,
+                accountAddress: effects.negative.address,
+            },
+            expectedOutput: {
+                type: 'sent',
+                txid: 'txid1',
+                blockTime: 1631753600,
+                amount: '-20',
+                fee: '10',
+                targets: [
+                    {
+                        addresses: ['address2'],
+                        amount: '10',
+                        isAccountTarget: false,
+                        isAddress: true,
+                        n: 0,
+                    },
+                ],
+                tokens: [],
+                internalTransfers: [],
+                details: {
+                    size: 100,
+                    totalInput: '20',
+                    totalOutput: '10',
+                    vin: [
+                        {
+                            txid: 'txid1',
+                            version: 'legacy',
+                            isAddress: true,
+                            isAccountOwned: true,
+                            n: 0,
+                            value: effects.negative.amount.abs().toString(),
+                            addresses: [effects.negative.address],
+                        },
+                    ],
+                    vout: [
+                        {
+                            txid: 'txid1',
+                            version: 'legacy',
+                            isAddress: true,
+                            isAccountOwned: false,
+                            n: 0,
+                            value: effects.positive.amount.abs().toString(),
+                            addresses: [effects.positive.address],
+                        },
+                    ],
+                },
             },
         },
     ],

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -12,6 +12,42 @@ const instructions = {
         },
     },
     notParsed: {},
+    tokenTransfer: {
+        parsed: {
+            info: {
+                authority: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                destination: '2SyRvfaD5abg8j4cRfHViFXRh5KThuBBEU24RX8Cgrm3',
+                mint: 'So11111111111111111111111111111111111111112',
+                source: 'FRoT98CfAt984ZS9n1rmtw1p9nrTCzCcC6sygivztyZN',
+                tokenAmount: {
+                    amount: '2000000',
+                    decimals: 9,
+                    uiAmount: 0.002,
+                    uiAmountString: '0.002',
+                },
+            },
+            type: 'transferChecked',
+        },
+        program: 'spl-token',
+    },
+    secondTokenTransfer: {
+        parsed: {
+            info: {
+                authority: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                destination: 'H8TGGw7Z85w1wDxcH3aTBAyCoCYsDQZrKUim7fwtKAMs',
+                mint: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                source: '2Bwv9hYm3isiJtUJoWSiy46Na612c4xzNszp5NckWofu',
+                tokenAmount: {
+                    amount: '2',
+                    decimals: 1,
+                    uiAmount: 2,
+                    uiAmountString: '2',
+                },
+            },
+            type: 'transferChecked',
+        },
+        program: 'spl-token',
+    },
 };
 
 const parsedTransactions = {
@@ -100,6 +136,42 @@ const parsedTransactions = {
             },
         },
     },
+    singleTokenTransfer: {
+        transaction: {
+            meta: {},
+            transaction: {
+                signatures: ['txid1'],
+                message: {
+                    accountKeys: [
+                        { pubkey: { toString: () => 'address1' } },
+                        { pubkey: { toString: () => 'address2' } },
+                    ],
+                    instructions: [instructions.tokenTransfer],
+                },
+            },
+            version: 'legacy',
+            blockTime: 1631753600,
+            slot: 5,
+        },
+    },
+    multiTokenTransfer: {
+        transaction: {
+            meta: {},
+            transaction: {
+                signatures: ['txid1'],
+                message: {
+                    accountKeys: [
+                        { pubkey: { toString: () => 'address1' } },
+                        { pubkey: { toString: () => 'address2' } },
+                    ],
+                    instructions: [instructions.tokenTransfer, instructions.secondTokenTransfer],
+                },
+            },
+            version: 'legacy',
+            blockTime: 1631753600,
+            slot: 5,
+        },
+    },
 };
 
 const effects = {
@@ -110,6 +182,31 @@ const effects = {
     positive: {
         address: 'address2',
         amount: new BigNumber(10),
+    },
+};
+
+const tokenEffects = {
+    sent: {
+        type: 'sent',
+        standard: 'SPL',
+        from: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+        to: 'GrwHUG2U6Nmr2CHjQ2kesKzbjMwvCNytcMAbhQxq1Jyd',
+        contract: '6YuhWADZyAAxAaVKPm1G5N51RvDBXsnWo4SfsJ47wSoK',
+        decimals: 9,
+        name: '6YuhWADZyAAxAaVKPm1G5N51RvDBXsnWo4SfsJ47wSoK',
+        symbol: '6Yu...',
+        amount: '10',
+    },
+    recv: {
+        type: 'recv',
+        standard: 'SPL',
+        from: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+        to: 'GrwHUG2U6Nmr2CHjQ2kesKzbjMwvCNytcMAbhQxq1Jyd',
+        contract: '6YuhWADZyAAxAaVKPm1G5N51RvDBXsnWo4SfsJ47wSoK',
+        decimals: 9,
+        name: '6YuhWADZyAAxAaVKPm1G5N51RvDBXsnWo4SfsJ47wSoK',
+        symbol: '6Yu...',
+        amount: '20',
     },
 };
 
@@ -179,6 +276,7 @@ export const fixtures = {
                 },
                 effects: [],
                 accountAddress: 'myAddress',
+                tokenEffects: [],
             },
             expectedOutput: 'failed',
         },
@@ -194,6 +292,7 @@ export const fixtures = {
                 },
                 effects: [effects.negative],
                 accountAddress: effects.negative.address,
+                tokenEffects: [],
             },
             expectedOutput: 'unknown',
         },
@@ -209,6 +308,7 @@ export const fixtures = {
                 },
                 effects: [effects.negative],
                 accountAddress: effects.negative.address,
+                tokenEffects: [],
             },
             expectedOutput: 'unknown',
         },
@@ -227,6 +327,7 @@ export const fixtures = {
                 },
                 effects: [effects.negative],
                 accountAddress: effects.negative.address,
+                tokenEffects: [],
             },
             expectedOutput: 'self',
         },
@@ -237,6 +338,7 @@ export const fixtures = {
                 transaction: parsedTransactions.justWithFee.transaction,
                 effects: [effects.negative],
                 accountAddress: effects.negative.address,
+                tokenEffects: [],
             },
             expectedOutput: 'sent',
         },
@@ -247,6 +349,7 @@ export const fixtures = {
                 transaction: parsedTransactions.justWithFee.transaction,
                 effects: [effects.positive],
                 accountAddress: effects.positive.address,
+                tokenEffects: [],
             },
             expectedOutput: 'recv',
         },
@@ -256,8 +359,29 @@ export const fixtures = {
                 transaction: parsedTransactions.justWithFee.transaction,
                 effects: [effects.positive],
                 accountAddress: 'someOtherAddress',
+                tokenEffects: [],
             },
             expectedOutput: 'unknown',
+        },
+        {
+            description: 'should return "sent" for token transfer',
+            input: {
+                transaction: parsedTransactions.justWithFee.transaction,
+                effects: [effects.negative],
+                accountAddress: 'someOtherAddress',
+                tokenEffects: [tokenEffects.sent],
+            },
+            expectedOutput: 'sent',
+        },
+        {
+            description: 'should return "recv" for token receive',
+            input: {
+                transaction: parsedTransactions.justWithFee.transaction,
+                effects: [],
+                accountAddress: 'someOtherAddress',
+                tokenEffects: [tokenEffects.recv],
+            },
+            expectedOutput: 'recv',
         },
     ],
     getTargets: [
@@ -384,6 +508,68 @@ export const fixtures = {
                     },
                 ],
             },
+        },
+    ],
+    getTokens: [
+        {
+            description: 'should return an empty array if transaction contains no token transfers',
+            input: {
+                transaction: parsedTransactions.basic.transaction,
+                accountAddress: 'someAddress',
+                slotToBlockHeightMapping: {},
+            },
+            expectedOutput: [],
+        },
+        {
+            description: 'parses a single token transfer',
+            input: {
+                transaction: parsedTransactions.singleTokenTransfer.transaction,
+                accountAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+            },
+            expectedOutput: [
+                {
+                    type: 'sent',
+                    standard: 'SPL',
+                    from: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                    to: '2SyRvfaD5abg8j4cRfHViFXRh5KThuBBEU24RX8Cgrm3',
+                    contract: 'So11111111111111111111111111111111111111112',
+                    decimals: 9,
+                    name: 'So11111111111111111111111111111111111111112',
+                    symbol: 'So1...',
+                    amount: '2000000',
+                },
+            ],
+        },
+        {
+            description: 'parses multiple token transfers',
+            input: {
+                transaction: parsedTransactions.multiTokenTransfer.transaction,
+                accountAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+            },
+            expectedOutput: [
+                {
+                    type: 'sent',
+                    standard: 'SPL',
+                    from: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                    to: '2SyRvfaD5abg8j4cRfHViFXRh5KThuBBEU24RX8Cgrm3',
+                    contract: 'So11111111111111111111111111111111111111112',
+                    decimals: 9,
+                    name: 'So11111111111111111111111111111111111111112',
+                    symbol: 'So1...',
+                    amount: '2000000',
+                },
+                {
+                    type: 'sent',
+                    standard: 'SPL',
+                    from: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                    to: 'H8TGGw7Z85w1wDxcH3aTBAyCoCYsDQZrKUim7fwtKAMs',
+                    contract: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                    decimals: 1,
+                    name: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                    symbol: 'DH1...',
+                    amount: '2',
+                },
+            ],
         },
     ],
     transformTransaction: [

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -1,6 +1,8 @@
 import { ParsedTransactionWithMeta } from '@solana/web3.js';
 
-import { extractAccountBalanceDiff, getTransactionEffects, getTxType } from '../solana';
+import { Transaction } from '@trezor/blockchain-link-types';
+
+import { extractAccountBalanceDiff, getTargets, getTransactionEffects, getTxType } from '../solana';
 import { fixtures } from './fixtures/solana';
 
 describe('solana/utils', () => {
@@ -33,6 +35,19 @@ describe('solana/utils', () => {
                 const result = getTxType(
                     input.transaction as ParsedTransactionWithMeta,
                     input.effects,
+                    input.accountAddress,
+                );
+                expect(result).toEqual(expectedOutput);
+            });
+        });
+    });
+
+    describe('getTargets', () => {
+        fixtures.getTargets.forEach(({ description, input, expectedOutput }) => {
+            it(description, () => {
+                const result = getTargets(
+                    input.effects,
+                    input.txType as Transaction['type'],
                     input.accountAddress,
                 );
                 expect(result).toEqual(expectedOutput);

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -2,7 +2,13 @@ import { ParsedTransactionWithMeta } from '@solana/web3.js';
 
 import { Transaction } from '@trezor/blockchain-link-types';
 
-import { extractAccountBalanceDiff, getTargets, getTransactionEffects, getTxType } from '../solana';
+import {
+    extractAccountBalanceDiff,
+    getAmount,
+    getTargets,
+    getTransactionEffects,
+    getTxType,
+} from '../solana';
 import { fixtures } from './fixtures/solana';
 
 describe('solana/utils', () => {
@@ -50,6 +56,15 @@ describe('solana/utils', () => {
                     input.txType as Transaction['type'],
                     input.accountAddress,
                 );
+                expect(result).toEqual(expectedOutput);
+            });
+        });
+    });
+
+    describe('getAmount', () => {
+        fixtures.getAmount.forEach(({ description, input, expectedOutput }) => {
+            it(description, () => {
+                const result = getAmount(input.accountEffect, input.txType as Transaction['type']);
                 expect(result).toEqual(expectedOutput);
             });
         });

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -1,6 +1,6 @@
 import { ParsedTransactionWithMeta } from '@solana/web3.js';
 
-import { extractAccountBalanceDiff, getTransactionEffects } from '../solana';
+import { extractAccountBalanceDiff, getTransactionEffects, getTxType } from '../solana';
 import { fixtures } from './fixtures/solana';
 
 describe('solana/utils', () => {
@@ -21,6 +21,19 @@ describe('solana/utils', () => {
             it(description, () => {
                 const result = getTransactionEffects(
                     input.transaction as ParsedTransactionWithMeta,
+                );
+                expect(result).toEqual(expectedOutput);
+            });
+        });
+    });
+
+    describe('getTxType', () => {
+        fixtures.getTxType.forEach(({ description, input, expectedOutput }) => {
+            it(description, () => {
+                const result = getTxType(
+                    input.transaction as ParsedTransactionWithMeta,
+                    input.effects,
+                    input.accountAddress,
                 );
                 expect(result).toEqual(expectedOutput);
             });

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -1,0 +1,29 @@
+import { ParsedTransactionWithMeta } from '@solana/web3.js';
+
+import { extractAccountBalanceDiff, getTransactionEffects } from '../solana';
+import { fixtures } from './fixtures/solana';
+
+describe('solana/utils', () => {
+    describe('extractAccountBalanceDiff', () => {
+        fixtures.extractAccountBalanceDiff.forEach(({ description, input, expectedOutput }) => {
+            it(description, () => {
+                const result = extractAccountBalanceDiff(
+                    input.transaction as ParsedTransactionWithMeta,
+                    input.address,
+                );
+                expect(result).toEqual(expectedOutput);
+            });
+        });
+    });
+
+    describe('getTransactionEffects', () => {
+        fixtures.getTransactionEffects.forEach(({ description, input, expectedOutput }) => {
+            it(description, () => {
+                const result = getTransactionEffects(
+                    input.transaction as ParsedTransactionWithMeta,
+                );
+                expect(result).toEqual(expectedOutput);
+            });
+        });
+    });
+});

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -9,6 +9,7 @@ import {
     getTargets,
     getTransactionEffects,
     getTxType,
+    transformTransaction,
 } from '../solana';
 import { fixtures } from './fixtures/solana';
 
@@ -77,6 +78,18 @@ describe('solana/utils', () => {
                 const result = getDetails(
                     input.transaction as ParsedTransactionWithMeta,
                     input.effects,
+                    input.accountAddress,
+                );
+                expect(result).toEqual(expectedOutput);
+            });
+        });
+    });
+
+    describe('transformTransaction', () => {
+        fixtures.transformTransaction.forEach(({ description, input, expectedOutput }) => {
+            it(description, () => {
+                const result = transformTransaction(
+                    input.transaction as ParsedTransactionWithMeta,
                     input.accountAddress,
                 );
                 expect(result).toEqual(expectedOutput);

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -91,6 +91,7 @@ describe('solana/utils', () => {
                 const result = transformTransaction(
                     input.transaction as ParsedTransactionWithMeta,
                     input.accountAddress,
+                    input.slotToBlockHeightMapping as Record<number, number>,
                 );
                 expect(result).toEqual(expectedOutput);
             });

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -5,6 +5,7 @@ import { Transaction } from '@trezor/blockchain-link-types';
 import {
     extractAccountBalanceDiff,
     getAmount,
+    getDetails,
     getTargets,
     getTransactionEffects,
     getTxType,
@@ -65,6 +66,19 @@ describe('solana/utils', () => {
         fixtures.getAmount.forEach(({ description, input, expectedOutput }) => {
             it(description, () => {
                 const result = getAmount(input.accountEffect, input.txType as Transaction['type']);
+                expect(result).toEqual(expectedOutput);
+            });
+        });
+    });
+
+    describe('getDetails', () => {
+        fixtures.getDetails.forEach(({ description, input, expectedOutput }) => {
+            it(description, () => {
+                const result = getDetails(
+                    input.transaction as ParsedTransactionWithMeta,
+                    input.effects,
+                    input.accountAddress,
+                );
                 expect(result).toEqual(expectedOutput);
             });
         });

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -1,4 +1,5 @@
 import { ParsedTransactionWithMeta } from '@solana/web3.js';
+import { TokenTransfer } from 'packages/blockchain-link-types/lib';
 
 import { Transaction } from '@trezor/blockchain-link-types';
 
@@ -7,7 +8,8 @@ import {
     getAmount,
     getDetails,
     getTargets,
-    getTransactionEffects,
+    getTokens,
+    getNativeEffects,
     getTxType,
     transformTransaction,
 } from '../solana';
@@ -29,9 +31,7 @@ describe('solana/utils', () => {
     describe('getTransactionEffects', () => {
         fixtures.getTransactionEffects.forEach(({ description, input, expectedOutput }) => {
             it(description, () => {
-                const result = getTransactionEffects(
-                    input.transaction as ParsedTransactionWithMeta,
-                );
+                const result = getNativeEffects(input.transaction as ParsedTransactionWithMeta);
                 expect(result).toEqual(expectedOutput);
             });
         });
@@ -44,6 +44,7 @@ describe('solana/utils', () => {
                     input.transaction as ParsedTransactionWithMeta,
                     input.effects,
                     input.accountAddress,
+                    input.tokenEffects as TokenTransfer[],
                 );
                 expect(result).toEqual(expectedOutput);
             });
@@ -78,6 +79,18 @@ describe('solana/utils', () => {
                 const result = getDetails(
                     input.transaction as ParsedTransactionWithMeta,
                     input.effects,
+                    input.accountAddress,
+                );
+                expect(result).toEqual(expectedOutput);
+            });
+        });
+    });
+
+    describe('getTokens', () => {
+        fixtures.getTokens.forEach(({ description, input, expectedOutput }) => {
+            it(description, () => {
+                const result = getTokens(
+                    input.transaction as ParsedTransactionWithMeta,
                     input.accountAddress,
                 );
                 expect(result).toEqual(expectedOutput);

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -3,7 +3,9 @@ import type * as MessageTypes from '@trezor/blockchain-link-types/lib/messages';
 import { CustomError } from '@trezor/blockchain-link-types/lib/constants/errors';
 import { BaseWorker, ContextType, CONTEXT } from '../baseWorker';
 import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/lib/constants';
-import { Connection, PublicKey } from '@solana/web3.js';
+import { Connection, ParsedTransactionWithMeta, PublicKey } from '@solana/web3.js';
+import { Transaction } from '../..';
+import { solanaUtils } from '@trezor/blockchain-link-utils';
 
 export type SolanaAPI = Connection;
 
@@ -77,20 +79,23 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
     const transactionsPage = await fetchTransactionPage(request);
 
-    // TODO(vl): parse transaction page
+    const transactions = transactionsPage
+        .map(tx => solanaUtils.transformTransaction(tx, payload.descriptor))
+        .filter((tx): tx is Transaction => !!tx);
 
     const account: AccountInfo = {
         descriptor: payload.descriptor,
         balance: accountInfo.lamports.toString(), // TODO(vl): check if this should also include staking balances
         availableBalance: accountInfo.lamports.toString(), // TODO(vl): revisit to make sure that what getAccountInfo returns is actually available balance
-        empty: accountInfo.lamports === 0, // TODO(vl): this is not correct, it should depend on the length of transaction history
-        // TODO(vl): transaction history
+        empty: !!transactions.length,
         history: {
-            total: -1,
+            total: transactions.length,
             unconfirmed: 0,
-            transactions: undefined,
+            transactions,
+            txids: transactions.map(({ txid }) => txid),
         },
     };
+
     return Promise.resolve({
         type: RESPONSES.GET_ACCOUNT_INFO,
         payload: account,

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -65,6 +65,7 @@ const fetchTransactionPage = async (
 
 const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => {
     const { payload } = request;
+    const { details = 'basic' } = payload;
     const api = await request.connect();
 
     const accountInfo = await api.getAccountInfo(new PublicKey(payload.descriptor));
@@ -88,57 +89,62 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
         } as const);
     }
 
+    const getTransactionPage = async (txIds: string[]) => {
+        const transactionsPage = await fetchTransactionPage(api, txIds);
+        const uniqueTransactionSlots = Array.from(new Set(transactionsPage.map(tx => tx.slot)));
+
+        const slotToBlockHeightMapping = (
+            await Promise.all(
+                uniqueTransactionSlots.map(async slot => {
+                    const { blockHeight } = await api.getParsedBlock(slot, {
+                        maxSupportedTransactionVersion: 0,
+                    });
+                    return blockHeight;
+                }),
+            )
+        ).reduce(
+            (acc, curr, i) => ({ ...acc, [uniqueTransactionSlots[i]]: curr }),
+            {} as Record<number, number | null>,
+        );
+
+        return transactionsPage
+            .map(tx =>
+                solanaUtils.transformTransaction(tx, payload.descriptor, slotToBlockHeightMapping),
+            )
+            .filter((tx): tx is Transaction => !!tx);
+    };
+
+    const allTxIds = Array.from(new Set(await getAllSignatures(api, payload.descriptor)));
+
+    const pageNumber = payload.page ? payload.page - 1 : 0;
     // for the first page of txs, payload.page is undefined, for the second page is 2
-    const page = payload.page ? payload.page - 1 : 0;
     const pageSize = payload.pageSize || 10; // TODO(vl): change to 25
 
-    const allSignatures = Array.from(new Set(await getAllSignatures(api, payload.descriptor)));
-    const pageStartIndex = page * pageSize;
-    const pageEndIndex = Math.min(pageStartIndex + pageSize, allSignatures.length);
+    const pageStartIndex = pageNumber * pageSize;
+    const pageEndIndex = Math.min(pageStartIndex + pageSize, allTxIds.length);
 
-    const transactionsPage = await fetchTransactionPage(
-        api,
-        allSignatures.slice(pageStartIndex, pageEndIndex),
-    );
+    const txIdPage = allTxIds.slice(pageStartIndex, pageEndIndex);
 
-    const uniqueTransactionSlots = Array.from(new Set(transactionsPage.map(tx => tx.slot)));
-
-    const slotToBlockHeightMapping = (
-        await Promise.all(
-            uniqueTransactionSlots.map(async slot => {
-                const { blockHeight } = await api.getParsedBlock(slot, {
-                    maxSupportedTransactionVersion: 0,
-                });
-                return blockHeight;
-            }),
-        )
-    ).reduce(
-        (acc, curr, i) => ({ ...acc, [uniqueTransactionSlots[i]]: curr }),
-        {} as Record<number, number | null>,
-    );
-
-    const transactions = transactionsPage
-        .map(tx =>
-            solanaUtils.transformTransaction(tx, payload.descriptor, slotToBlockHeightMapping),
-        )
-        .filter((tx): tx is Transaction => !!tx);
+    const transactionPage = details === 'txs' ? await getTransactionPage(txIdPage) : undefined;
 
     const account: AccountInfo = {
         descriptor: payload.descriptor,
         balance: accountInfo.lamports.toString(), // TODO(vl): check if this should also include staking balances
         availableBalance: accountInfo.lamports.toString(), // TODO(vl): revisit to make sure that what getAccountInfo returns is actually available balance
-        empty: !!transactions.length,
+        empty: !!allTxIds.length,
         history: {
-            total: allSignatures.length,
+            total: allTxIds.length,
             unconfirmed: 0,
-            transactions,
-            txids: transactions.map(({ txid }) => txid),
+            transactions: transactionPage,
+            txids: txIdPage,
         },
-        page: {
-            total: allSignatures.length,
-            index: page,
-            size: transactions.length,
-        },
+        page: transactionPage
+            ? {
+                  total: allTxIds.length,
+                  index: pageNumber,
+                  size: transactionPage.length,
+              }
+            : undefined,
     };
 
     return Promise.resolve({

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -79,8 +79,26 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
     const transactionsPage = await fetchTransactionPage(request);
 
+    const uniqueTransactionSlots = Array.from(new Set(transactionsPage.map(tx => tx.slot)));
+
+    const slotToBlockHeightMapping = (
+        await Promise.all(
+            uniqueTransactionSlots.map(async slot => {
+                const { blockHeight } = await api.getParsedBlock(slot, {
+                    maxSupportedTransactionVersion: 0,
+                });
+                return blockHeight;
+            }),
+        )
+    ).reduce(
+        (acc, curr, i) => ({ ...acc, [uniqueTransactionSlots[i]]: curr }),
+        {} as Record<number, number | null>,
+    );
+
     const transactions = transactionsPage
-        .map(tx => solanaUtils.transformTransaction(tx, payload.descriptor))
+        .map(tx =>
+            solanaUtils.transformTransaction(tx, payload.descriptor, slotToBlockHeightMapping),
+        )
         .filter((tx): tx is Transaction => !!tx);
 
     const account: AccountInfo = {

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -12,26 +12,37 @@ export type SolanaAPI = Connection;
 type Context = ContextType<SolanaAPI>;
 type Request<T> = T & Context;
 
-const fetchTransactionPage = async (
-    request: Request<MessageTypes.GetAccountInfo>,
-): Promise<ParsedTransactionWithMeta[]> => {
-    const { payload } = request;
-    const api = await request.connect();
+const getAllSignatures = async (
+    api: SolanaAPI,
+    descriptor: MessageTypes.GetAccountInfo['payload']['descriptor'],
+) => {
     let lastSignature: string | undefined;
+    let keepFetching = true;
+    let allSignatures: string[] = [];
 
-    const signatures = (
-        await api.getSignaturesForAddress(new PublicKey(payload.descriptor), {
-            before: lastSignature,
-            limit: payload.pageSize || 25,
-        })
-    ).map(info => info.signature);
+    const limit = 100;
+    while (keepFetching) {
+        const signaturesInfos = // eslint-disable-next-line no-await-in-loop
+            await api.getSignaturesForAddress(new PublicKey(descriptor), {
+                before: lastSignature,
+                limit,
+            });
 
-    // deduplicate
-    const confirmedSignatures = Array.from(new Set(signatures));
+        const signatures = signaturesInfos.map(info => info.signature);
+        lastSignature = signatures[signatures.length - 1];
+        keepFetching = signatures.length === limit;
+        allSignatures = [...allSignatures, ...signatures];
+    }
+    return allSignatures;
+};
 
+const fetchTransactionPage = async (
+    api: SolanaAPI,
+    signatures: string[],
+): Promise<ParsedTransactionWithMeta[]> => {
     // avoid requests that are too big by querying max N signatures at once
     const perChunk = 50; // items per chunk
-    const confirmedSignatureChunks = confirmedSignatures.reduce((resultArray, item, index) => {
+    const confirmedSignatureChunks = signatures.reduce((resultArray, item, index) => {
         const chunkIndex = Math.floor(index / perChunk);
         if (!resultArray[chunkIndex]) {
             resultArray[chunkIndex] = []; // start a new chunk
@@ -77,7 +88,18 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
         } as const);
     }
 
-    const transactionsPage = await fetchTransactionPage(request);
+    // for the first page of txs, payload.page is undefined, for the second page is 2
+    const page = payload.page ? payload.page - 1 : 0;
+    const pageSize = payload.pageSize || 10; // TODO(vl): change to 25
+
+    const allSignatures = Array.from(new Set(await getAllSignatures(api, payload.descriptor)));
+    const pageStartIndex = page * pageSize;
+    const pageEndIndex = Math.min(pageStartIndex + pageSize, allSignatures.length);
+
+    const transactionsPage = await fetchTransactionPage(
+        api,
+        allSignatures.slice(pageStartIndex, pageEndIndex),
+    );
 
     const uniqueTransactionSlots = Array.from(new Set(transactionsPage.map(tx => tx.slot)));
 
@@ -107,10 +129,15 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
         availableBalance: accountInfo.lamports.toString(), // TODO(vl): revisit to make sure that what getAccountInfo returns is actually available balance
         empty: !!transactions.length,
         history: {
-            total: transactions.length,
+            total: allSignatures.length,
             unconfirmed: 0,
             transactions,
             txids: transactions.map(({ txid }) => txid),
+        },
+        page: {
+            total: allSignatures.length,
+            index: page,
+            size: transactions.length,
         },
     };
 

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -131,7 +131,7 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
         descriptor: payload.descriptor,
         balance: accountInfo.lamports.toString(), // TODO(vl): check if this should also include staking balances
         availableBalance: accountInfo.lamports.toString(), // TODO(vl): revisit to make sure that what getAccountInfo returns is actually available balance
-        empty: !!allTxIds.length,
+        empty: !allTxIds.length,
         history: {
             total: allTxIds.length,
             unconfirmed: 0,

--- a/packages/blockchain-link/tests/integration/solana.ts
+++ b/packages/blockchain-link/tests/integration/solana.ts
@@ -1,5 +1,115 @@
+import { AccountInfoParams } from '@trezor/blockchain-link-types';
 import BlockchainLink from '../../lib';
 import SolanaWorker, { SolanaAPI } from '../../lib/workers/solana';
+
+const id = 79;
+const descriptor = '2MLmmoKgCrxVEzMeGatnjdABYS5RXsQSNikcWrmnvQna';
+const balance = '1000000000';
+
+const fixtures = {
+    accountInfoRequest: [
+        {
+            name: 'basic',
+            input: {
+                id,
+                descriptor,
+                details: 'basic',
+            },
+            result: {
+                descriptor,
+                balance,
+                availableBalance: balance,
+                empty: false,
+                history: {
+                    total: 1,
+                    unconfirmed: 0,
+                    transactions: undefined,
+                    txids: ['deadbeaf'],
+                },
+                page: undefined,
+            },
+        },
+        {
+            name: 'txIds',
+            input: {
+                id,
+                descriptor,
+                details: 'txIds',
+            },
+            result: {
+                descriptor,
+                balance,
+                availableBalance: balance,
+                empty: false,
+                history: {
+                    total: 1,
+                    unconfirmed: 0,
+                    transactions: undefined,
+                    txids: ['deadbeaf'],
+                },
+                page: undefined,
+            },
+        },
+        {
+            name: 'txs',
+            input: {
+                id,
+                descriptor,
+                details: 'txs',
+            },
+            result: {
+                descriptor,
+                balance,
+                availableBalance: balance,
+                empty: false,
+                history: {
+                    total: 1,
+                    unconfirmed: 0,
+                    transactions: [
+                        {
+                            type: 'self',
+                            txid: 'deadbeaf',
+                            blockTime: 1631753600,
+                            amount: '20',
+                            fee: '20',
+                            targets: [
+                                {
+                                    n: 0,
+                                    addresses: [descriptor],
+                                    isAddress: true,
+                                    amount: '20',
+                                    isAccountTarget: true,
+                                },
+                            ],
+                            tokens: [],
+                            internalTransfers: [],
+                            details: {
+                                size: 0,
+                                totalInput: '20',
+                                totalOutput: '0',
+                                vin: [
+                                    {
+                                        txid: 'deadbeaf',
+                                        version: 'legacy',
+                                        isAddress: true,
+                                        isAccountOwned: true,
+                                        n: 0,
+                                        value: '20',
+                                        addresses: [descriptor],
+                                    },
+                                ],
+                                vout: [],
+                            },
+                            blockHeight: 195138557,
+                        },
+                    ],
+                    txids: ['deadbeaf'],
+                },
+                page: { total: 1, index: 0, size: 1 },
+            },
+        },
+    ],
+};
 
 export const solanaApi = {
     getGenesisHash: () => '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d',
@@ -15,6 +125,40 @@ export const solanaApi = {
     }),
     getBlockHeight: () => 195138557,
     rpcEndpoint: 'dummyUrl',
+    getAccountInfo: () => ({
+        address: descriptor,
+        lamports: {
+            toString: () => balance,
+        },
+    }),
+    getSignaturesForAddress: () => [
+        {
+            signature: 'deadbeaf',
+            slot: 1,
+            err: null,
+            memo: null,
+            confirmationStatus: 'confirmed',
+        },
+    ],
+    getParsedTransactions: () => [
+        {
+            meta: {
+                preBalances: [200],
+                postBalances: [180],
+                fee: 20,
+            },
+            transaction: {
+                signatures: ['deadbeaf'],
+                message: {
+                    accountKeys: [{ pubkey: { toString: () => descriptor } }],
+                    instructions: [],
+                },
+            },
+            version: 'legacy',
+            blockTime: 1631753600,
+            slot: 5,
+        },
+    ],
 } as unknown as SolanaAPI;
 
 describe(`Solana`, () => {
@@ -24,7 +168,7 @@ describe(`Solana`, () => {
 
     worker.tryConnect = () => Promise.resolve(solanaApi);
 
-    beforeEach(() => {
+    beforeAll(() => {
         blockchain = new BlockchainLink({
             name: 'Solana',
             worker: () => worker,
@@ -33,7 +177,7 @@ describe(`Solana`, () => {
         });
     });
 
-    afterEach(() => {
+    afterAll(() => {
         blockchain.dispose();
     });
 
@@ -50,4 +194,11 @@ describe(`Solana`, () => {
             decimals: 9,
         });
     });
+
+    fixtures.accountInfoRequest.forEach(f =>
+        it(`Get account info ${f.name}`, async () => {
+            const result = await blockchain.getAccountInfo(f.input as AccountInfoParams);
+            expect(result).toEqual(f.result);
+        }),
+    );
 });

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/IODetails.tsx
@@ -454,7 +454,8 @@ export const IODetails = ({ tx }: IODetailsProps) => {
 
     return (
         <Wrapper>
-            <AnalyzeInBlockbookBanner txid={tx.txid} />
+            {/* solana is not supported by blockbook */}
+            {network?.networkType !== 'solana' && <AnalyzeInBlockbookBanner txid={tx.txid} />}
             <IOSectionColumn tx={tx} inputs={tx.details.vin} outputs={tx.details.vout} />
         </Wrapper>
     );

--- a/suite-common/suite-config/src/settings.ts
+++ b/suite-common/suite-config/src/settings.ts
@@ -1,5 +1,5 @@
 export const settingsCommonConfig = {
     MAX_ACCOUNTS: 10,
     FRESH_ADDRESS_LIMIT: 20,
-    TXS_PER_PAGE: 25,
+    TXS_PER_PAGE: 10,
 } as const;

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -425,9 +425,9 @@ export const networks = {
         testnet: false,
         // features: ['tokens', 'staking'],
         explorer: {
-            tx: '', // TODO(vl): add explorer links
-            account: '',
-            address: '',
+            tx: 'https://explorer.solana.com/tx/',
+            account: 'https://explorer.solana.com/address/',
+            address: 'https://explorer.solana.com/address/',
         },
         support: {
             [DeviceModelInternal.T2T1]: '2.4.3', // TODO(vl): revisit, for now just anything above 2.0.0

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -59,16 +59,21 @@ const connect = (draft: BlockchainState, info: BlockchainInfo) => {
 
     const isHttp = isHttpProtocol(info.url); // can use dynamic backend url settings
 
+    // solana rpc nodes do not have explorer, so we cannot use backend as explorer
+    const isBackendAlsoExplorer = network.networkType !== 'solana';
+
+    const useBackendAsExplorer = isHttp && isBackendAlsoExplorer;
+
     draft[network.symbol] = {
         url: info.url,
         explorer: {
             tx: `${
-                isHttp
+                useBackendAsExplorer
                     ? info.url + getBlockExplorerUrlSuffix(network.explorer.tx)
                     : network.explorer.tx
             }`,
             account: `${
-                isHttp
+                useBackendAsExplorer
                     ? info.url + getBlockExplorerUrlSuffix(network.explorer.account)
                     : network.explorer.account
             }`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8876,6 +8876,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/blockchain-link-utils@workspace:packages/blockchain-link-utils"
   dependencies:
+    "@solana/web3.js": ^1.78.4
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"


### PR DESCRIPTION
## Description

Only accounts for token transfers, not minting or account creation etc, in line with existing tx history items in suite.
Note also that since your system account isn't actually the one receiving tokens, we don't show them in the tx history.  
If this should be added, we would need to run the TX history parsing for each token account, is this desirable? cc: @PeterBenc 
